### PR TITLE
Improve how the current balance is displayed

### DIFF
--- a/src/app/components/pages/address-detail/address-detail.component.html
+++ b/src/app/components/pages/address-detail/address-detail.component.html
@@ -3,6 +3,43 @@
   <h2 class="-not-xs">{{ address }}</h2>
   <h2 class="-xs-only">{{ 'addressDetail.title' | translate }}</h2>
 
+  <!-- Balance boxes. -->
+  <div class="balance-container">
+    <div>
+      <ng-container *ngIf="!dataLoaded">
+        {{ loadingMsg | translate }}
+      </ng-container>
+      <ng-container *ngIf="dataLoaded">
+        {{ balance.toString() | amount:true:'first' }}
+        <span class="coin-name">{{ balance.toString() | amount:true:'last' }}</span>
+        <div *ngIf="pendingCoins && !pendingCoins.isEqualTo(0)" class="small">
+          {{
+            ('addressDetail.' + (pendingCoins.isEqualTo(1) || pendingCoins.isEqualTo(-1) ? 'singular' : 'plural' ) + 'PendingCoins') | translate:{ amount:
+              (pendingCoins.isGreaterThan(0) ? '+' : '') + (pendingCoins.toString() | amount:true:'first')
+            }
+          }}
+        </div>
+      </ng-container>
+    </div>
+    <div>
+      <ng-container *ngIf="!dataLoaded">
+        {{ loadingMsg | translate }}
+      </ng-container>
+      <ng-container *ngIf="dataLoaded">
+        {{ hoursBalance.toString() | amount:false:'first' }}
+        <span class="coin-name">{{ hoursBalance.toString() | amount:false:'last' }}</span>
+        <div *ngIf="pendingHours && !pendingHours.isEqualTo(0)" class="small">
+          {{
+            ('addressDetail.' + (pendingHours.isEqualTo(1) || pendingHours.isEqualTo(-1) ? 'singular' : 'plural' ) + 'PendingCoins') | translate:{ amount:
+              (pendingHours.isGreaterThan(0) ? '+' : '') + (pendingHours.toString() | amount:true:'first')
+            }
+          }}
+        </div>
+      </ng-container>
+      <div *ngIf="false" class="small">+5 pending</div>
+    </div>
+  </div>
+
   <!-- Top data table -->
   <div class="element-details">
     <!-- QR code (small windows only) -->
@@ -15,29 +52,33 @@
     <div class="-row" *ngIf="!hasManyTransactions">
       <span>{{ 'addressDetail.totalReceived' | translate }}</span><br class="-xs-only" />
       <div>
-        {{ dataLoaded ? ((totalReceived.toString() | amount)) : (loadingMsg | translate) }}
-        <span *ngIf="dataLoaded && pendingIncomingCoins && pendingIncomingCoins.isGreaterThan(0)">&nbsp;({{ (pendingIncomingCoins.toString() | amount:true:'first') + ' ' + ((pendingIncomingCoins.isEqualTo(1) || pendingIncomingCoins.isEqualTo(-1) ? 'addressDetail.singularPendingCoin': 'addressDetail.pluralPendingCoins') | translate) }})</span>
+        <ng-container *ngIf="!dataLoaded">
+          {{ loadingMsg | translate }}
+        </ng-container>
+        <ng-container *ngIf="dataLoaded">
+          <span>{{ totalReceived.toString() | amount }}</span>&nbsp;
+          <span *ngIf="pendingIncomingCoins && pendingIncomingCoins.isGreaterThan(0)">({{
+            ('addressDetail.' + (pendingIncomingCoins.isEqualTo(1) || pendingIncomingCoins.isEqualTo(-1) ? 'singular' : 'plural' ) + 'PendingCoins') | translate:{ amount:
+              (pendingIncomingCoins.isGreaterThan(0) ? '+' : '') + (pendingIncomingCoins.toString() | amount:true:'first')
+            }
+          }})</span>
+        </ng-container>
       </div>
     </div>
     <div class="-row" *ngIf="!hasManyTransactions">
       <span>{{ 'addressDetail.totalSent' | translate }}</span><br class="-xs-only" />
       <div>
-        {{ dataLoaded ? ((totalSent.toString() | amount)) : (loadingMsg | translate) }}
-        <span *ngIf="dataLoaded && pendingOutgoingCoins && pendingOutgoingCoins.isGreaterThan(0)">&nbsp;({{ (pendingOutgoingCoins.toString() | amount:true:'first') + ' ' + ((pendingOutgoingCoins.isEqualTo(1) || pendingOutgoingCoins.isEqualTo(-1) ? 'addressDetail.singularPendingCoin': 'addressDetail.pluralPendingCoins') | translate) }})</span>
-      </div>
-    </div>
-    <div class="-row">
-      <span>{{ 'addressDetail.currentBalance' | translate }}</span><br class="-xs-only" />
-      <div>
-        {{ dataLoaded ? ((balance.toString() | amount)) : (loadingMsg | translate) }}
-        <span *ngIf="dataLoaded && pendingCoins && !pendingCoins.isEqualTo(0)">&nbsp;({{ (pendingCoins.isGreaterThan(0) ? '+' : '') + (pendingCoins.toString() | amount:true:'first') + ' ' + ((pendingCoins.isEqualTo(1) || pendingCoins.isEqualTo(-1) ? 'addressDetail.singularPendingCoin': 'addressDetail.pluralPendingCoins') | translate) }})</span>
-      </div>
-    </div>
-    <div class="-row">
-      <span>{{ 'addressDetail.hoursBalance' | translate }}</span><br class="-xs-only" />
-      <div>
-        {{ dataLoaded ? ((hoursBalance.toString() | amount:false)) : (loadingMsg | translate) }}
-        <span *ngIf="dataLoaded && pendingHours && !pendingHours.isEqualTo(0)">&nbsp;({{ (pendingHours.isGreaterThan(0) ? '+' : '') + (pendingHours.toString() | amount:false:'first') + ' ' + ((pendingHours.isEqualTo(1) || pendingHours.isEqualTo(-1) ? 'addressDetail.singularPendingCoin': 'addressDetail.pluralPendingCoins') | translate) }})</span>
+        <ng-container *ngIf="!dataLoaded">
+          {{ loadingMsg | translate }}
+        </ng-container>
+        <ng-container *ngIf="dataLoaded">
+          <span>{{ totalReceived.toString() | amount }}</span>&nbsp;
+          <span *ngIf="pendingOutgoingCoins && pendingOutgoingCoins.isGreaterThan(0)">({{
+            ('addressDetail.' + (pendingOutgoingCoins.isEqualTo(1) || pendingOutgoingCoins.isEqualTo(-1) ? 'singular' : 'plural' ) + 'PendingCoins') | translate:{ amount:
+              (pendingOutgoingCoins.isGreaterThan(0) ? '+' : '') + (pendingOutgoingCoins.toString() | amount:true:'first')
+            }
+          }})</span>
+        </ng-container>
       </div>
     </div>
     <div class="-row"><span>{{ 'addressDetail.tools' | translate }}</span><br class="-xs-only" /><div> <a [routerLink]="'/app/unspent/' + address" class="-link" *ngIf="address">{{ 'addressDetail.unspentOutputs' | translate }}</a> <span *ngIf="!address">{{ loadingMsg }}</span> </div></div>

--- a/src/app/components/pages/address-detail/address-detail.component.scss
+++ b/src/app/components/pages/address-detail/address-detail.component.scss
@@ -1,5 +1,31 @@
 @import '../../../../assets/scss/_variables.scss';
 
+.balance-container {
+  padding-left: 20px;
+  padding-bottom: 5px;
+  margin-top: -10px;
+
+  > div {
+    display: inline-block;
+    padding: 14px;
+    margin-right: 10px;
+    font-size: $siz-normal-text;
+    font-weight: 700;
+    border-radius: 5px;
+    background-color: $col-odd-background;
+
+    .small {
+      font-weight: 500;
+      font-size: $siz-small-text;
+    }
+
+    .coin-name {
+      font-weight: 500;
+      font-size: $siz-mini-text;
+    }
+  }
+}
+
 .-right-margin {
   padding-right: 150px;
 

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -66,13 +66,11 @@
     "txsNumber": "# of Transactions",
     "totalReceived": "Total Received",
     "totalSent": "Total Sent",
-    "currentBalance": "Current Coins",
-    "hoursBalance": "Current Hours",
     "tools": "Tools",
     "unspentOutputs": "Unspent outputs",
     "withoutTransactions": "Without transactions",
-    "singularPendingCoin": "pending",
-    "pluralPendingCoins": "pending"
+    "singularPendingCoins": "{{ amount }} pending",
+    "pluralPendingCoins": "{{ amount }} pending"
   },
   "unspentOutputs": {
     "title": "Unspent Outputs",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -66,13 +66,11 @@
     "txsNumber": "# de Transacciones",
     "totalReceived": "Total Recibido",
     "totalSent": "Total Enviado",
-    "currentBalance": "Monedas Actuales",
-    "hoursBalance": "Horas Actuales",
     "tools": "Herramientas",
     "unspentOutputs": "Salidas no Gastadas",
     "withoutTransactions": "Sin transacciones",
-    "singularPendingCoin": "pendiente",
-    "pluralPendingCoins": "pendientes"
+    "singularPendingCoins": "{{ amount }} pendiente",
+    "pluralPendingCoins": "{{ amount }} pendientes"
   },
   "unspentOutputs": {
     "title": "Salidas No Gastadas",

--- a/src/assets/i18n/es_base.json
+++ b/src/assets/i18n/es_base.json
@@ -66,13 +66,11 @@
     "txsNumber": "# of Transactions",
     "totalReceived": "Total Received",
     "totalSent": "Total Sent",
-    "currentBalance": "Current Coins",
-    "hoursBalance": "Current Hours",
     "tools": "Tools",
     "unspentOutputs": "Unspent outputs",
     "withoutTransactions": "Without transactions",
-    "singularPendingCoin": "pending",
-    "pluralPendingCoins": "pending"
+    "singularPendingCoins": "{{ amount }} pending",
+    "pluralPendingCoins": "{{ amount }} pending"
   },
   "unspentOutputs": {
     "title": "Unspent Outputs",

--- a/src/assets/i18n/zh.json
+++ b/src/assets/i18n/zh.json
@@ -62,8 +62,6 @@
     "txsNumber": "# 的交易",
     "totalReceived": "总共收取",
     "totalSent": "总共发出",
-    "currentBalance": "当前币额",
-    "hoursBalance": "当前币时数",
     "tools": "工具",
     "unspentOutputs": "未花费输出",
     "withoutTransactions": "没有交易"

--- a/src/assets/i18n/zh_base.json
+++ b/src/assets/i18n/zh_base.json
@@ -62,8 +62,6 @@
     "txsNumber": "# of Transactions",
     "totalReceived": "Total Received",
     "totalSent": "Total Sent",
-    "currentBalance": "Current Coins",
-    "hoursBalance": "Current Hours",
     "tools": "Tools",
     "unspentOutputs": "Unspent outputs",
     "withoutTransactions": "Without transactions"

--- a/src/assets/scss/_variables.scss
+++ b/src/assets/scss/_variables.scss
@@ -53,3 +53,4 @@ $siz-normal-margin: 15px;
 $siz-header-text: 24px;
 $siz-normal-text: 14px;
 $siz-small-text: 12px;
+$siz-mini-text: 10px;


### PR DESCRIPTION
Fixes #1

Changes:
- The way in which the current balance of an address is displayed was changed to make it easier to see.
![balance](https://user-images.githubusercontent.com/34079003/79669867-c3e21680-818c-11ea-8b3a-6dff37ed18a0.png)

- The way in which the pending coins are shown was improved to work well with other languages.

Does this change need to mentioned in CHANGELOG.md?
No

@iketheadore @jdknives please take a llok at the change.